### PR TITLE
Merge main into develop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ develop ]
   push:
-    branches: [ main ]
+    branches: [ develop ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
       fail-fast: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,207 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,8 @@ For detailed project specifications, command structure, and feature descriptions
 
 ### Platform & Hosting
 - **Repository**: Hosted on GitHub
-- **CI/CD**: Tests run on GitHub Actions runners (to be implemented)
-- **Distribution**: Will be published via Homebrew (not yet implemented)
+- **CI/CD**: Fully implemented with GitHub Actions
+- **Distribution**: Automated release system with Homebrew formula generation
 - **Target Platforms**: macOS, Linux, Windows WSL
 
 ### Testing Strategy
@@ -57,3 +57,132 @@ When choosing between features or approaches:
 - Any new dependencies should be justified for core functionality
 - Consider impact on future Homebrew packaging
 - Document any new requirements clearly
+
+## Release Management for Agents
+
+**IMPORTANT**: This project has a fully automated release system. Agents can create and publish releases by following these exact steps.
+
+### Release Workflow Overview
+The release system uses semantic versioning and automated GitHub Actions workflows. When agents create releases, they should follow this process:
+
+### Step-by-Step Release Instructions for Agents
+
+#### 1. Pre-Release Validation
+Before creating any release, agents MUST:
+```bash
+# Ensure all tests pass
+python3 test_wt.py ./wt
+
+# Check current version
+./scripts/version.sh current
+```
+
+#### 2. Version Bumping
+Use the version management script to bump version appropriately:
+```bash
+# For bug fixes (0.2.0 → 0.2.1)
+./scripts/version.sh bump patch
+
+# For new features (0.2.0 → 0.3.0)  
+./scripts/version.sh bump minor
+
+# For breaking changes (0.2.0 → 1.0.0)
+./scripts/version.sh bump major
+```
+
+**What this does automatically:**
+- Updates `__version__` in the `wt` script
+- Updates `CHANGELOG.md` with new version entry and date
+- Creates a git commit with the version bump
+
+#### 3. Create Git Tag
+```bash
+./scripts/version.sh tag
+```
+
+**What this does:**
+- Creates an annotated git tag (e.g., `v0.2.1`)
+- Validates working directory is clean
+- Prevents duplicate tags
+
+#### 4. Trigger Automated Release
+```bash
+# Push the tag to trigger GitHub Actions release workflow
+git push origin v[VERSION]  # e.g., git push origin v0.2.1
+```
+
+**What happens automatically:**
+- GitHub Actions runs full test suite on multiple platforms
+- Build script (`build.sh`) creates release assets:
+  - Standalone `wt` executable
+  - Universal tarball (`wt-X.Y.Z-universal.tar.gz`)
+  - Universal zip for Windows users
+  - SHA256 checksums (`checksums.txt`)
+- Creates GitHub release with auto-generated notes
+- Generates Homebrew formula as artifact
+
+### Release Types and When to Use Them
+
+- **Patch Release** (`bump patch`): Bug fixes, security patches, minor improvements
+- **Minor Release** (`bump minor`): New features, enhancements, backwards-compatible changes
+- **Major Release** (`bump major`): Breaking changes, major architecture changes
+
+### Agent Release Command Examples
+
+When asked to create a release, agents should determine the appropriate type:
+
+```bash
+# Example: Bug fix release
+./scripts/version.sh bump patch
+./scripts/version.sh tag
+git push origin v$(./scripts/version.sh current)
+
+# Example: New feature release  
+./scripts/version.sh bump minor
+./scripts/version.sh tag
+git push origin v$(./scripts/version.sh current)
+```
+
+### Verification Steps
+After triggering a release, agents should:
+1. Monitor GitHub Actions workflow completion
+2. Verify release appears at: `https://github.com/[USERNAME]/wt/releases`
+3. Check that all assets are present in the release
+4. Confirm checksums file is included
+
+### Emergency Procedures
+If a release fails or has critical issues:
+1. **DO NOT** delete the git tag immediately
+2. Mark the GitHub release as "pre-release" if possible
+3. Create a hotfix branch for immediate fixes
+4. Use patch version bump for hotfix releases
+
+### Build System Details
+- **Build Script**: `build.sh` - Creates all release assets with validation
+- **Test Integration**: Full test suite runs before any release
+- **Multi-platform**: Automated testing on Ubuntu, macOS, Windows
+- **Checksums**: SHA256 hashes generated for all binary assets
+- **Packaging**: Multiple formats (tarball, zip) for different platforms
+
+### Important Files for Releases
+- `scripts/version.sh` - Version management utility
+- `build.sh` - Production build script
+- `.github/workflows/release.yml` - Release automation
+- `.github/workflows/test.yml` - Testing pipeline
+- `CHANGELOG.md` - Release notes and history
+- `.github/RELEASE_TEMPLATE.md` - Release checklist
+
+### Agent Success Criteria
+A successful release by an agent includes:
+- ✅ Tests pass before release creation
+- ✅ Version bump committed and tagged
+- ✅ GitHub Actions workflow completes successfully
+- ✅ Release artifacts are generated and accessible
+- ✅ Release appears on GitHub releases page
+- ✅ Checksums match expected values
+
+### Troubleshooting Common Issues
+- **Version mismatch**: Ensure git tag version matches script version
+- **Test failures**: Fix failing tests before attempting release
+- **Build failures**: Check `build.sh` output for specific errors
+- **Permission issues**: Verify GitHub token has release permissions

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Brian Wishan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Purpose

This PR merges the main branch INTO develop to consolidate the repository before deleting the main branch.

## Direction

**main → develop** (correct direction this time\!)

## Background

The main and develop branches had divergent histories. This merge brings the original repository state from main into develop, creating a unified history while preserving all the CI/CD and build system work in develop.

## After this merge:
- develop will contain everything from both branches
- main branch can be safely deleted
- develop will become the primary/default branch

## Changes Merged from Main

- Original repository foundation
- Base .gitignore patterns (now combined with develop's patterns)
- Any additional configurations from the main branch

## Preserved from Develop

- Complete CI/CD pipeline with GitHub Actions
- Build system with automated releases  
- Testing workflows for multi-platform support
- Release management tools and documentation
- Version management utilities
- All existing development work

## Merge Resolution

- Resolved .gitignore conflicts by combining the best patterns from both branches
- Used `--allow-unrelated-histories` to merge divergent commit histories
- All functionality from both branches is preserved

## Next Steps

1. **Merge this PR** to bring main into develop
2. **Delete the main branch** as planned
3. **Set develop as the default branch** 
4. **Continue development** on the unified develop branch

This creates a clean, unified repository with complete CI/CD capabilities.